### PR TITLE
Removed dependancy on custom MonoMac build

### DIFF
--- a/AppStoreWindow/Extensions.cs
+++ b/AppStoreWindow/Extensions.cs
@@ -24,6 +24,7 @@
 using MonoMac.AppKit;
 using MonoMac.CoreGraphics;
 using System.Drawing;
+using System.Runtime.InteropServices;
 
 namespace AshokGelal.AppStoreWindow
 {
@@ -83,6 +84,21 @@ namespace AshokGelal.AppStoreWindow
         {
             return (window.StyleMask & NSWindowStyle.TexturedBackground) == NSWindowStyle.TexturedBackground;
         }
+    }
+
+    internal static class NSGraphicsExtensions
+    {
+        [DllImport (MonoMac.Constants.AppKitLibrary, EntryPoint="NSDrawWindowBackground")]
+        public extern static void DrawWindowBackground (RectangleF aRect);
+
+        [DllImport (MonoMac.Constants.AppKitLibrary, EntryPoint="NSSetFocusRingStyle")]
+        public extern static void SetFocusRingStyle (NSFocusRingPlacement placement);
+
+        [DllImport (MonoMac.Constants.AppKitLibrary, EntryPoint="NSDisableScreenUpdates")]
+        public extern static void DisableScreenUpdates ();
+
+        [DllImport (MonoMac.Constants.AppKitLibrary, EntryPoint="NSEnableScreenUpdates")]
+        public extern static void EnableScreenUpdates ();
     }
 
     public static class RectangleExtensions

--- a/AppStoreWindow/TitleBarView.cs
+++ b/AppStoreWindow/TitleBarView.cs
@@ -80,7 +80,7 @@ namespace AshokGelal.AppStoreWindow
                 }
                 window.SetAutorecalculatesContentBorderThickness(false, NSRectEdge.MaxYEdge);
                 window.SetContentBorderThickness(contentBorderThickness, NSRectEdge.MaxYEdge);
-                NSGraphics.DrawWindowBackground(drawingRect);
+                NSGraphicsExtensions.DrawWindowBackground(drawingRect);
             }
             else
             {


### PR DESCRIPTION
Looks like converting it to unix line ending has caused some oddity with the diff :-1: 

I've changed added a static class 'NSGraphicsExtensions' which contains your previous MonoMac NSGraphics changes.  

This seems to resolve the problem and means you can use the library with Xamarin.Mac as well! I think it might need some testing though as I only confirmed it built and looked alright.
